### PR TITLE
change import of "./data" to be non-relative 

### DIFF
--- a/gitlab-hook-server.go
+++ b/gitlab-hook-server.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/nurza/logo"
 
-	"./data"
+	"github.com/ZenlabsFR/GitlabHookServer/data"
 
 	"bytes"
 	"encoding/json"


### PR DESCRIPTION
to prevent local import warning during `go get`
